### PR TITLE
Feature/request and authentication improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,14 +86,14 @@ In a standard startup IBeam performs the following:
 1. **Copy inputs** from the Inputs Directory to Gateway's `root` folder (if provided).
 1. **Ensure the Gateway is running** by calling the tickle endpoint. If not:
     1. Start the Gateway in a new shell.
-1. **Ensure the Gateway is authenticated** by calling the validation endpoint. If not:
+1. **Ensure the Gateway has an active session that is  authenticated** by calling the tickle endpoint. If not:
     1. Create a new Chrome Driver instance using `selenium`.
     1. Start a virtual display using `pyvirtualdisplay`.
     1. Access the Gateway's authentication website.
     1. Once loaded, input username and password and submit the form.
     1. Wait for the login confirmation and quit the website.
     1. Verify once again if Gateway is running and authenticated.
-1. **Start the maintenance**, attempting to keep the Gateway alive and authenticated.
+1. **Start the maintenance**, attempting to keep the Gateway alive and authenticated. Will repeat login if finds no active session or the session is not authenticated. 
 
 
 ## <a name="security"></a>Security

--- a/ibeam/ibeam_starter.py
+++ b/ibeam/ibeam_starter.py
@@ -24,7 +24,7 @@ def parse_args():
     parser.add_argument('-s', '--start', action='store_true', help='Start the gateway.')
     parser.add_argument('-t', '--tickle', action='store_true', help='Tickle the gateway.')
     parser.add_argument('-u', '--user', action='store_true', help='Get the user.')
-    parser.add_argument('-l', '--validate', action='store_true', help='Validate authentication.')
+    parser.add_argument('-c', '--check', action='store_true', help='Check if session is authenticated.')
     parser.add_argument('-v', '--verbose', action='store_true', help='Verbose output.')
 
     args = parser.parse_args()
@@ -49,9 +49,12 @@ if __name__ == '__main__':
     elif args.authenticate:
         success = client.try_authenticating()
         _LOGGER.info(f'Gateway {"" if success else "not "}authenticated.')
-    elif args.validate:
-        success = client.validate()
-        _LOGGER.info(f'Gateway {"" if success else "not "}authenticated.')
+    elif args.check:
+        status = client.get_status()
+        if status[1]:
+            _LOGGER.info(f'Gateway session {"" if status[2] else "not "}authenticated.')
+        else:
+            _LOGGER.info(f'No active Gateway session.')
     elif args.tickle:
         success = client.tickle()
         _LOGGER.info(f'Gateway {"" if success else "not "}running.')

--- a/ibeam/src/gateway_client.py
+++ b/ibeam/src/gateway_client.py
@@ -85,7 +85,7 @@ _REQUEST_TIMEOUT = int(os.environ.get('IBEAM_REQUEST_TIMEOUT', 15))
 """How many seconds to wait for a request to complete."""
 
 _OAUTH_TIMEOUT = int(os.environ.get('IBEAM_OAUTH_TIMEOUT', 15))
-"""How many seconds to wait for a OAuth login request to complete."""
+"""How many seconds to wait for the OAuth login request to complete."""
 
 logging.getLogger('ibeam').setLevel(getattr(logging, _LOG_LEVEL))
 

--- a/ibeam/src/gateway_client.py
+++ b/ibeam/src/gateway_client.py
@@ -1,6 +1,8 @@
+import json
 import logging
 import os
 import shutil
+import socket
 import ssl
 import subprocess
 import sys
@@ -49,6 +51,12 @@ _ROUTE_USER = os.environ.get('IBEAM_ROUTE_USER', '/v1/api/one/user')
 _ROUTE_VALIDATE = os.environ.get('IBEAM_ROUTE_VALIDATE', '/v1/portal/sso/validate')
 """Gateway route with validation call."""
 
+_ROUTE_REAUTHENTICATE = os.environ.get('IBEAM_ROUTE_REAUTHENTICATE', '/v1/portal/iserver/reauthenticate?force=true')
+"""Gateway route with reauthentication call."""
+
+_ROUTE_AUTH_STATUS = os.environ.get('IBEAM_ROUTE_AUTH_STATUS', '/v1/api/iserver/auth/status')
+"""Gateway route with authentication status call."""
+
 _ROUTE_TICKLE = os.environ.get('IBEAM_ROUTE_TICKLE', '/v1/api/tickle')
 """Gateway route with tickle call."""
 
@@ -64,11 +72,17 @@ _SUBMIT_EL_ID = os.environ.get('IBEAM_SUBMIT_EL_ID', 'submitForm')
 _SUCCESS_EL_TEXT = os.environ.get('IBEAM_SUCCESS_EL_TEXT', 'Client login succeeds')
 """HTML element text indicating successful authentication."""
 
-_MAINTENANCE_INTERVAL = os.environ.get('IBEAM_MAINTENANCE_INTERVAL', 60)
+_MAINTENANCE_INTERVAL = int(os.environ.get('IBEAM_MAINTENANCE_INTERVAL', 60))
 """How many seconds between each maintenance."""
 
 _LOG_LEVEL = os.environ.get('IBEAM_LOG_LEVEL', 'INFO')
 """Verbosity level of the logger used."""
+
+_REQUEST_RETRIES = int(os.environ.get('IBEAM_REQUEST_RETRIES', 1))
+"""How many times to reattempt a request to the gateway."""
+
+_REQUEST_TIMEOUT = int(os.environ.get('IBEAM_REQUEST_TIMEOUT', 15))
+"""How many seconds to wait for a request to complete."""
 
 logging.getLogger('ibeam').setLevel(getattr(logging, _LOG_LEVEL))
 
@@ -107,7 +121,7 @@ def new_chrome_driver(driver_path, headless: bool = True):
     return webdriver.Chrome(driver_path, options=options)
 
 
-def authenticate_gateway(driver, account, password, key: str = None, base_url: str = None):
+def authenticate_gateway(driver, account, password, key: str = None, base_url: str = None) -> bool:
     """
     Authenticates the currently running gateway.
 
@@ -128,11 +142,11 @@ def authenticate_gateway(driver, account, password, key: str = None, base_url: s
         except WebDriverException as e:
             if 'net::ERR_CONNECTION_REFUSED' in e.msg:
                 _LOGGER.error(
-                    'Connection to Gateway refused. This could indicate IB Gateway is not running. Consider increasing IBEAM_GATEWAY_STARTUP wait buffer.')
+                    'Connection to Gateway refused. This could indicate IB Gateway is not running. Consider increasing IBEAM_GATEWAY_STARTUP wait buffer')
                 return False
             if 'net::ERR_CONNECTION_CLOSED' in e.msg:
                 _LOGGER.error(
-                    f'Connection to Gateway failed. This could indicate IB Gateway is not running correctly or that its port {base_url.split(":")[2]} was already occupied.')
+                    f'Connection to Gateway failed. This could indicate IB Gateway is not running correctly or that its port {base_url.split(":")[2]} was already occupied')
                 return False
             else:
                 raise e
@@ -163,7 +177,7 @@ def authenticate_gateway(driver, account, password, key: str = None, base_url: s
         success = True
     except Exception as e:
         try:
-            raise RuntimeError('Error encountered during authentication.') from e
+            raise RuntimeError('Error encountered during authentication') from e
         except Exception as full_e:
             _LOGGER.exception(full_e)
             success = False
@@ -228,6 +242,7 @@ class GatewayClient():
         self._ssl_context = ssl.SSLContext()
         self.do_tls = os.path.isfile(self.cecert_jks_path) and os.path.isfile(self.cecert_pem_path)
         if self.do_tls:
+            _LOGGER.debug('Certificates found and will be used for TLS verification')
             shutil.copy2(self.cecert_jks_path,
                          os.path.join(self.gateway_dir, 'root', os.path.basename(self.cecert_jks_path)))
 
@@ -279,69 +294,126 @@ class GatewayClient():
             self.server_process = processes[0].pid
             _LOGGER.info(f'Gateway started with pid: {self.server_process}')
 
-            # _LOGGER.debug('Gateway is already running.')
         return processes[0].pid
 
-    def _authenticate(self):
+    def _authenticate(self) -> bool:
         driver = new_chrome_driver(self.driver_path)
         return authenticate_gateway(driver, self.account, self.password, self.key, self.base_url)
 
-    def try_authenticating(self):
-        if not self.validate():
-            _LOGGER.info('Gateway not authenticated, authenticating...')
+    # def _reauthenticate(self):
+    #     self._try_request(self.base_url + _ROUTE_REAUTHENTICATE, False)
+
+    def try_authenticating(self, request_retries=1) -> bool:
+        status = self.get_status(max_attempts=request_retries)
+        if status[2]:  # running and authenticated
+            return True
+        elif not status[0]:  # no gateway running
+            return False
+        else:
+            if status[1]:
+                _LOGGER.info('Gateway session found but not authenticated, authenticating...')
+
+                """
+                Annoyingly this is an async request that takes arbitrary amount of time and returns no
+                meaningful response. For now we stick with full login instead of calling reauthenticate. 
+                """
+                # self._reauthenticate()
+            else:
+                _LOGGER.info('No active sessions, logging in...')
 
             success = self._authenticate()
-            _LOGGER.info(f'Authentication {"succeeded" if success else "failed"}.')
+            _LOGGER.info(f'Login {"succeeded" if success else "failed"}')
             if not success:
                 return False
+            # self._try_request(self.base_url + _ROUTE_VALIDATE, False, max_attempts=REQUEST_RETRIES)
 
-            if not self.validate():  # double check if authenticated
-                if self.tickle():
-                    _LOGGER.error('Gateway running but not authenticated.')
+            time.sleep(1)  # a small buffer for session to be authenticated
+
+            # double check if authenticated
+            status = self.get_status(max_attempts=request_retries)
+            if not status[2]:
+                if status[1]:
+                    _LOGGER.error('Gateway session active but not authenticated')
+                elif status[0]:
+                    _LOGGER.error('Gateway running but has no active sessions')
                 else:
-                    _LOGGER.error('Gateway not running and not authenticated.')
+                    _LOGGER.error('Gateway not running and not authenticated')
                 return False
+
         return True
 
     def _url_request(self, url):
-        _LOGGER.debug(f'HTTP{"S" if self.do_tls else ""} request to: {url}')
-        # Empty context allows us to ignore certificates, given we're on the same network. This may be a bad idea.
-        return urllib.request.urlopen(url, context=self._ssl_context, timeout=15)
+        _LOGGER.debug(f'HTTPS{"" if self.do_tls else " (unverified)"} request to: {url}')
+        return urllib.request.urlopen(url, context=self._ssl_context, timeout=_REQUEST_TIMEOUT)
 
-    def _try_request(self, url, only_tickle: bool = True):
-        """Attempts a HTTP request and returns a boolean flag indicating whether it was successful."""
-        try:
-            self._url_request(url)
-            return True
-        except HTTPError as e:
-            if e.code == 401 and not only_tickle:
-                return False
-            else:  # todo: possibly other codes could appear when not authenticated, fix when necessary
-                return True
-        except URLError as e:
-            # print(e.reason)
-            reason = str(e.reason)
+    def _try_request(self, url, check_auth=False, max_attempts=1) -> (bool, bool, bool):
+        """Attempts a HTTP request and returns a tuple of three boolean flag indicating whether the gateway can be reached, whether there is an active session and whether it is authenticated. Attempts to repeat the request up to max_attempts times.
 
-            """
-                No connection... - happens when port isn't open
-                Cannot assign... - happens when calling a port taken by Docker but not served, when called from within the container.
-                Errno 0... - happens when calling a port taken by Docker but not served, when called from the host machine.
-            """
+        status[0] -> gateway running
+        status[1] -> active session present
+        status[2] -> session authenticated (equivalent to 'all good')
+        """
 
-            if 'No connection could be made because the target machine actively refused it' in reason \
-                    or 'Cannot assign requested address' in reason \
-                    or '[Errno 0] Error' in reason:
-                return False
+        def _request(attempt=0) -> (bool, bool, bool):
+            status = [False, False, False]
+            try:
+                response = self._url_request(url)
+                if check_auth:
+                    data = json.loads(response.read().decode('utf8'))
+                    return True, True, data['iserver']['authStatus']['authenticated']
+                else:
+                    return True, True, True
+            except HTTPError as e:
+                if e.code == 401:
+                    return True, False, False  # we expect this error, no need to log
+                else:  # todo: possibly other codes could appear when not authenticated, fix when necessary
+                    _LOGGER.exception(e)
+                    return True, False, False
+            except (URLError, socket.timeout) as e:
+                reason = str(e)
+
+                """
+                    No connection... - happens when port isn't open
+                    Cannot assign... - happens when calling a port taken by Docker but not served, when called from within the container.
+                    Errno 0... - happens when calling a port taken by Docker but not served, when called from the host machine.
+                """
+
+                if 'No connection could be made because the target machine actively refused it' in reason \
+                        or 'Cannot assign requested address' in reason \
+                        or '[Errno 0] Error' in reason:
+                    status = [False, False, False]
+                    pass  # we expect these errors and don't need to log them
+
+                elif "timed out" in reason \
+                        or "The read operation timed out" in reason:
+                    _LOGGER.error(
+                        f'Connection timeout after {_REQUEST_TIMEOUT} seconds. Consider increasing timeout by setting IBEAM_REQUEST_TIMEOUT environment variable. Error: {reason}')
+                    status = [True, False, False]
+                else:
+                    _LOGGER.exception(e)
+                    status = [True, False, False]
+
+            if max_attempts <= 1:
+                return status
             else:
-                _LOGGER.exception(e)
-        except Exception as e:
-            _LOGGER.exception(e)
+                if attempt >= max_attempts - 1:
+                    _LOGGER.debug(
+                        f'Max validate request retries reached after {max_attempts} attempts. Consider increasing the retries by setting IBEAM_REQUEST_RETRIES environment variable')
+                    return status
+                else:
+                    _LOGGER.debug(f'Attempt number {attempt + 2}')
+                    return _request(attempt + 1)
+
+        return _request(0)
+
+    def get_status(self, max_attempts=1) -> (bool, bool, bool):
+        return self._try_request(self.base_url + _ROUTE_TICKLE, True, max_attempts=max_attempts)
 
     def validate(self) -> bool:
-        return self._try_request(self.base_url + _ROUTE_VALIDATE, False)
+        return self._try_request(self.base_url + _ROUTE_VALIDATE, False)[1]
 
     def tickle(self) -> bool:
-        return self._try_request(self.base_url + _ROUTE_TICKLE, True)
+        return self._try_request(self.base_url + _ROUTE_TICKLE, True)[0]
 
     def user(self):
         try:
@@ -350,12 +422,12 @@ class GatewayClient():
         except Exception as e:
             _LOGGER.exception(e)
 
-    def start_and_authenticate(self) -> bool:
+    def start_and_authenticate(self, request_retries=1) -> bool:
         """Starts the gateway and authenticates using the credentials stored."""
 
         self.try_starting()
 
-        success = self.try_authenticating()
+        success = self.try_authenticating(request_retries=request_retries)
 
         return success
 
@@ -364,13 +436,16 @@ class GatewayClient():
         job_defaults = {'coalesce': False, 'max_instances': self._threads}
         self._scheduler = BlockingScheduler(executors=executors, job_defaults=job_defaults, timezone='UTC')
         self._scheduler.add_job(self._maintenance, trigger=IntervalTrigger(seconds=_MAINTENANCE_INTERVAL))
-        _LOGGER.info(f'Starting maintenance with interval {_MAINTENANCE_INTERVAL} seconds.')
+        _LOGGER.info(f'Starting maintenance with interval {_MAINTENANCE_INTERVAL} seconds')
         self._scheduler.start()
 
     def _maintenance(self):
         _LOGGER.debug('Maintenance')
 
-        self.start_and_authenticate()
+        success = self.start_and_authenticate(request_retries=_REQUEST_RETRIES)
+
+        if success:
+            _LOGGER.info('Gateway running and authenticated')
 
     def kill(self) -> bool:
         processes = find_procs_by_name(_GATEWAY_PROCESS_MATCH)

--- a/ibeam/src/gateway_client.py
+++ b/ibeam/src/gateway_client.py
@@ -32,7 +32,7 @@ from ibeam import config
 
 config.initialize()
 
-_GATEWAY_STARTUP = os.environ.get('IBEAM_GATEWAY_STARTUP', 3)
+_GATEWAY_STARTUP = int(os.environ.get('IBEAM_GATEWAY_STARTUP', 3))
 """How many seconds to wait before attempting to communicate with the gateway after its startup."""
 
 _GATEWAY_BASE_URL = os.environ.get('IBEAM_GATEWAY_BASE_URL', "https://localhost:5000")


### PR DESCRIPTION
Fix: #1
Fix: #2


- added retries and timeout settings
- maintenance will now retry requests up to IBEAM_REQUEST_RETRIES (default 1)
- refactored tickle/validate logic
- now uses tickle to verify authentication and extend sessions, instead of validate
- now checks for authentication status apart from successful requests
- deprecated `-l`/`--validate` standalone argument