### PR TITLE
SECURITY UPDATE: ports are open to other people on local network

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     env_file:
       - env.list
     ports:
-      - 5000:5000
-      - 5001:5001
+      - 127.0.0.1:5000:5000
+      - 127.0.0.1:5001:5001
     network_mode: bridge # Required due to clientportal.gw IP restrictions
     restart: 'no' # Prevents IBEAM_MAX_FAILED_AUTH from being exceeded


### PR DESCRIPTION
Port mapping with docker-compose exposes ports not only on your local machine but also to others on your network. For example, if you're at a coffee shop, someone else can make calls to your IP address port 5000 or 5001.

See article:
https://vccolombo.github.io/blog/how-to-stop-docker-exposing-your-containers-to-the-world/

Fix:
Change docker-compose ports from
```
ports:
  - 5000:5000
  - 5001:5001
```

To
```
ports:
  - 127.0.0.1:5000:5000
  - 127.0.0.1:5001:5001
```