### PR TITLE
feat: Update docker image and modules to latest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11.3-slim-bullseye
+FROM python:3.12.4-slim-bookworm
 
 ENV PATH="/opt/venv/bin:$PATH" \
     JAVA_HOME="/usr/lib/jvm/default-java" \
@@ -24,7 +24,7 @@ RUN \
     # Install apt packages
     apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y default-jre dbus-x11 xfonts-base xfonts-100dpi \
-        xfonts-75dpi xfonts-cyrillic xfonts-scalable xorg xvfb gtk2-engines-pixbuf nano curl iputils-ping \
+        xfonts-75dpi xfonts-scalable xorg xvfb gtk2-engines-pixbuf nano curl iputils-ping \
         chromium chromium-driver build-essential && \
     # Install python packages
     pip install --upgrade pip setuptools wheel && \

--- a/Dockerfile_armv7
+++ b/Dockerfile_armv7
@@ -1,4 +1,4 @@
-FROM python:3.11.3-slim-bullseye
+FROM python:3.12.4-slim-bookworm
 
 ENV PATH="/opt/venv/bin:$PATH" \
     JAVA_HOME="/usr/lib/jvm/default-java" \
@@ -24,7 +24,7 @@ RUN \
     # Install apt packages
     apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y default-jre dbus-x11 xfonts-base xfonts-100dpi \
-        xfonts-75dpi xfonts-cyrillic xfonts-scalable xorg xvfb gtk2-engines-pixbuf nano curl iputils-ping \
+        xfonts-75dpi xfonts-scalable xorg xvfb gtk2-engines-pixbuf nano curl iputils-ping \
         chromium chromium-driver build-essential pkg-config libssl-dev  libffi-dev zlib1g-dev libjpeg-dev 
 
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "2.1"
-
 services:
   ibeam:
     image: voyz/ibeam

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-selenium==4.12.*
-cryptography==40.0.*
+selenium==4.22.*
+cryptography==42.0.*
 pyvirtualdisplay==3.0.*
 apscheduler==3.10.*
-psutil==5.9.*
-requests==2.30.*
-pillow==9.5.*
+psutil==6.0.*
+requests==2.32.*
+pillow==10.3.*


### PR DESCRIPTION
Changes include:
- Update docker base image to python 3.12.4 on bookworm
- Update pip requirements to latest versions at the time
- Update docker compose file to remove deprecated version

Only real difference which I wasn't able to fully test to tell if it causes a problem or not is that the xfonts-cyrillic package no longer seems to be in bookworm.