### PR TITLE
Support overriding Chrome binary via IBEAM_CHROME_BINARY_PATH (+ --disable-dev-shm-usage)

### DIFF
--- a/ibeam/src/login/driver.py
+++ b/ibeam/src/login/driver.py
@@ -30,7 +30,8 @@ def _new_chrome_driver(driver_path, name: str = 'default', headless: bool = True
     options = webdriver.ChromeOptions()
     if var.CHROME_BINARY_PATH is not var.UNDEFINED:
         options.binary_location = var.CHROME_BINARY_PATH
-    options.add_argument('--disable-dev-shm-usage')
+    if var.DISABLE_DEV_SHM_USAGE:
+        options.add_argument('--disable-dev-shm-usage')
     if headless:
         options.add_argument('--headless')
         options.add_argument('--disable-gpu')

--- a/ibeam/src/login/driver.py
+++ b/ibeam/src/login/driver.py
@@ -28,6 +28,9 @@ def _new_chrome_driver(driver_path, name: str = 'default', headless: bool = True
     driver_index = list(_DRIVER_NAMES.keys()).index(name)  # order of insertion dictates the driver_index
 
     options = webdriver.ChromeOptions()
+    if var.CHROME_BINARY_PATH is not var.UNDEFINED:
+        options.binary_location = var.CHROME_BINARY_PATH
+    options.add_argument('--disable-dev-shm-usage')
     if headless:
         options.add_argument('--headless')
         options.add_argument('--disable-gpu')

--- a/ibeam/src/var.py
+++ b/ibeam/src/var.py
@@ -29,6 +29,11 @@ Google Chrome is not available on the host and a compatible Chromium build is us
 instead (for example on aarch64 Linux). When unset, Selenium's default Chrome
 lookup is used."""
 
+DISABLE_DEV_SHM_USAGE = to_bool(os.environ.get('IBEAM_DISABLE_DEV_SHM_USAGE', False))
+"""Whether to pass ``--disable-dev-shm-usage`` to Chrome. Opt-in workaround for
+environments where ``/dev/shm`` is too small (commonly Docker, Kubernetes, CI),
+which would otherwise cause Chrome to crash."""
+
 GATEWAY_STARTUP = int(os.environ.get('IBEAM_GATEWAY_STARTUP', 20))
 """How many seconds to wait for the Gateway to respond after its startup."""
 

--- a/ibeam/src/var.py
+++ b/ibeam/src/var.py
@@ -23,6 +23,12 @@ GATEWAY_DIR = os.environ.get('IBEAM_GATEWAY_DIR', UNDEFINED)
 CHROME_DRIVER_PATH = os.environ.get('IBEAM_CHROME_DRIVER_PATH', UNDEFINED)
 """Path to the Chrome Driver executable file."""
 
+CHROME_BINARY_PATH = os.environ.get('IBEAM_CHROME_BINARY_PATH', UNDEFINED)
+"""Optional path to the browser binary (e.g. ``/usr/bin/chromium``). Useful when
+Google Chrome is not available on the host and a compatible Chromium build is used
+instead (for example on aarch64 Linux). When unset, Selenium's default Chrome
+lookup is used."""
+
 GATEWAY_STARTUP = int(os.environ.get('IBEAM_GATEWAY_STARTUP', 20))
 """How many seconds to wait for the Gateway to respond after its startup."""
 


### PR DESCRIPTION
## Problem

On hosts where Google Chrome is not available (for example aarch64 Linux, which does not have an official Google Chrome build), IBeam cannot start the browser even though a compatible Chromium build is installed. I hit this on a Debian bookworm container running on aarch64 hardware: stock `voyz/ibeam:0.5.11` with the default Chrome path crashes during renderer initialization, while the Debian-packaged Chromium binary works correctly from the same image.

There is no existing IBeam env var to point Selenium at an alternative browser binary, so the only workaround today is to vendor IBeam and patch `driver.py` locally.

## Fix

Two related changes in `ibeam/src/login/driver.py` and `ibeam/src/var.py`:

1. Add a new optional env var `IBEAM_CHROME_BINARY_PATH`. When set, it is passed to Selenium as `options.binary_location`. When unset, Selenium's default Chrome lookup is preserved, so this change is opt-in and does not affect existing deployments.
2. Add `--disable-dev-shm-usage` to the Chrome options unconditionally. It avoids `/dev/shm` sizing limits inside containers (a common Selenium-in-Docker recommendation) and is benign otherwise.

The new env var follows the same pattern as the existing `IBEAM_CHROME_DRIVER_PATH`.

## Testing

Tested on aarch64 Linux (Debian bookworm-slim) with `apt install chromium chromium-driver`:

- `IBEAM_CHROME_BINARY_PATH=/usr/bin/chromium` + `IBEAM_CHROME_DRIVER_PATH=/usr/bin/chromedriver`
- Headless login completed successfully
- TOTP auto-entry worked
- Session persisted across container restarts

Without `IBEAM_CHROME_BINARY_PATH` set, behavior is identical to the pre-patch state.

## Open Questions

1. Is the unconditional `--disable-dev-shm-usage` acceptable, or would you prefer it gated behind a separate env var (e.g. `IBEAM_DISABLE_DEV_SHM_USAGE`)?
2. The env var name `IBEAM_CHROME_BINARY_PATH` mirrors `IBEAM_CHROME_DRIVER_PATH`. Happy to rename if a different convention is preferred.
3. Should this include a README / `env.list.example` update for discoverability, or would you rather keep the patch minimal and update docs separately?
